### PR TITLE
fix: change data variable to match object in next()

### DIFF
--- a/client/src/Main/Monitor/Monitor.js
+++ b/client/src/Main/Monitor/Monitor.js
@@ -116,7 +116,7 @@ class Monitor extends Component {
       variables: {}
     }).subscribe({
       next (data) {
-        props.update(JSON.parse(data.state));
+        props.update(JSON.parse(data.data.state));
       }
     },() => console.log('error'));
   }


### PR DESCRIPTION
The shape of the payload in the `data` variable used in the next() method is actually `data.data.state` rather than `data.state` as currently coded. This causes JSON.parse(data.state) to operate on the string "undefined" which is invalid JSON. By applying the correct object hierarchy to the variable we're able to access the valid JSON present in the $state property.

Fixes #39