### PR TITLE
Deploy frontend in another folder to limit downtime

### DIFF
--- a/devops/provisioning/deploy.yml
+++ b/devops/provisioning/deploy.yml
@@ -21,3 +21,6 @@
 
   - name: Build frontend
     raw: "cd workflow-monitor/client && npm i && npm run build"
+
+  - name: Copy final build in the served folder
+    raw: "cp -r workflow-monitor/client/build workflow-monitor/client/build-prod"


### PR DESCRIPTION
The idea is to build the frontend in another folder than /build. 
Since Create React App does not have an option to name the build folder, we copy the contents of the /build folder to a /build-prod folder. 

This means we have to change the symlinks in our servers to link /var/www/caspr/current/build to ~/workflow-monitor/client/build-prod